### PR TITLE
Multi-platform build support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release UDX Worker
 
 on:
   push:
-    branches:
-      - latest
+    # branches:
+    #   - latest
 
 jobs:
   test-pipeline:
@@ -106,6 +106,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             usabilitydynamics/udx-worker:${{ needs.test-pipeline.outputs.semVer }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release UDX Worker
 
 on:
   push:
-    # branches:
-    #   - latest
+    branches:
+      - latest
 
 jobs:
   test-pipeline:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Run Development Pipeline
-        run: make dev-pipeline MULTIPLATFORM=true
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v2
@@ -37,6 +42,22 @@ jobs:
         with:
           useConfigFile: true
           configFilePath: ci/git-version.yml
+
+      - name: Build Docker image and export cache
+        uses: docker/build-push-action@v6
+        id: build-image
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          load: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: |
+            usabilitydynamics/udx-worker:${{ steps.gitversion.outputs.semVer }}
+            usabilitydynamics/udx-worker:latest
+          build-args: |
+            GIT_VERSION=${{ steps.gitversion.outputs.semVer }}
 
       - name: Generate changelog
         id: changelog
@@ -92,27 +113,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Push Docker image (cached)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
           tags: |
             usabilitydynamics/udx-worker:${{ needs.test-pipeline.outputs.semVer }}
             usabilitydynamics/udx-worker:latest
-          build-args: |
-            GIT_VERSION=${{ needs.test-pipeline.outputs.semVer }}
 
       - name: Log out from Docker Hub
         run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
 
   docker-release:
     runs-on: ubuntu-latest
-    needs: [github-release]
+    needs: [test-pipeline, github-release]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
 
       - name: Cache Docker layers
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Create GitHub Tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git tag ${{ needs.test-pipeline.outputs.semVer }}
           git push origin ${{ needs.test-pipeline.outputs.semVer }}
@@ -98,7 +98,7 @@ jobs:
           draft: false
           prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
   docker-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Run Development Pipeline
-        run: make dev-pipeline
+        run: make dev-pipeline MULTIPLATFORM=true
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,12 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: false
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=inline
+          cache-to: type=inline
           tags: |
             usabilitydynamics/udx-worker:${{ steps.gitversion.outputs.semVer }}
           build-args: |
-            GIT_VERSION=${{ steps.gitversion.outputs.semVer }}        
+            GIT_VERSION=${{ steps.gitversion.outputs.semVer }}    
 
       - name: Generate changelog
         id: changelog
@@ -124,11 +124,11 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=inline
+          cache-to: type=inline
           tags: |
             usabilitydynamics/udx-worker:${{ needs.test-pipeline.outputs.semVer }}
-            usabilitydynamics/udx-worker:latest
+            usabilitydynamics/udx-worker:latest  
 
       - name: Log out from Docker Hub
         run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: false
-          load: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,21 +43,20 @@ jobs:
           useConfigFile: true
           configFilePath: ci/git-version.yml
 
-      - name: Build Docker image and export cache
+      - name: Build Docker image
         uses: docker/build-push-action@v6
-        id: build-image
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
+          push: false
           load: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             usabilitydynamics/udx-worker:${{ steps.gitversion.outputs.semVer }}
-            usabilitydynamics/udx-worker:latest
           build-args: |
-            GIT_VERSION=${{ steps.gitversion.outputs.semVer }}
+            GIT_VERSION=${{ steps.gitversion.outputs.semVer }}        
 
       - name: Generate changelog
         id: changelog
@@ -104,7 +103,7 @@ jobs:
 
   docker-release:
     runs-on: ubuntu-latest
-    needs: [test-pipeline, github-release]
+    needs: [github-release]
     permissions:
       contents: write
     steps:
@@ -119,7 +118,7 @@ jobs:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Push Docker image (cached)
+      - name: Build and push Docker image (release)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -127,6 +126,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             usabilitydynamics/udx-worker:${{ needs.test-pipeline.outputs.semVer }}
             usabilitydynamics/udx-worker:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           tags: |
             usabilitydynamics/udx-worker:${{ steps.gitversion.outputs.semVer }}
           build-args: |
-            GIT_VERSION=${{ steps.gitversion.outputs.semVer }}    
+            GIT_VERSION=${{ steps.gitversion.outputs.semVer }}
 
       - name: Generate changelog
         id: changelog
@@ -113,6 +113,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -130,7 +135,7 @@ jobs:
           cache-to: type=inline
           tags: |
             usabilitydynamics/udx-worker:${{ needs.test-pipeline.outputs.semVer }}
-            usabilitydynamics/udx-worker:latest  
+            usabilitydynamics/udx-worker:latest
 
       - name: Log out from Docker Hub
         run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release UDX Worker
 
 on:
   push:
-    branches:
-      - latest
+    # branches:
+    #   - latest
 
 jobs:
   test-pipeline:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release UDX Worker
 
 on:
   push:
-    # branches:
-    #   - latest
+    branches:
+      - latest
 
 jobs:
   test-pipeline:
@@ -43,7 +43,7 @@ jobs:
           useConfigFile: true
           configFilePath: ci/git-version.yml
 
-      - name: Build Docker image
+      - name: Multi-arch build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -117,7 +117,7 @@ jobs:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push Docker image (release)
+      - name: Release the image
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,11 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install yq
-RUN curl -sL https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64.tar.gz | tar xz && \
-    mv yq_linux_amd64 /usr/bin/yq && \
+# Install yq (architecture-aware)
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
+    curl -sL https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_${ARCH}.tar.gz | tar xz && \
+    mv yq_linux_${ARCH} /usr/bin/yq && \
     rm -rf /tmp/*
 
 # Install Google Cloud SDK
@@ -51,15 +53,16 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install AWS CLI
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+# Install AWS CLI (architecture-aware)
+RUN ARCH=$(uname -m) && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm -rf awscliv2.zip aws /tmp/* /var/tmp/*
 
-# Install Azure CLI
-RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg && \
-    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+# Install Azure CLI (architecture-aware)
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends azure-cli=2.63.0-1~noble && \
     apt-get clean && \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build:
 	@echo "Building Docker image..."
 	@if [ "$(MULTIPLATFORM)" = "true" ]; then \
 		echo "Building Docker image for multiple platforms..."; \
-		docker buildx build --platform linux/amd64,linux/arm64 -t $(DOCKER_IMAGE) --push .; \
+		docker buildx build --platform linux/amd64,linux/arm64 -t $(DOCKER_IMAGE) .; \
 	else \
 		echo "Building Docker image for the local platform..."; \
 		docker build -t $(DOCKER_IMAGE) .; \

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,17 @@ stringify-creds:
 	done
 
 # Build the Docker image
+MULTIPLATFORM ?= false
+
 build:
 	@echo "Building Docker image..."
-	@docker build -t $(DOCKER_IMAGE) .
+	@if [ "$(MULTIPLATFORM)" = "true" ]; then \
+		echo "Building Docker image for multiple platforms..."; \
+		docker buildx build --platform linux/amd64,linux/arm64 -t $(DOCKER_IMAGE) --push .; \
+	else \
+		echo "Building Docker image for the local platform..."; \
+		docker build -t $(DOCKER_IMAGE) .; \
+	fi
 	@echo "Docker image build completed."
 
 # Run Docker container (supports interactive mode)

--- a/ci/git-version.yml
+++ b/ci/git-version.yml
@@ -2,5 +2,7 @@ mode: ContinuousDeployment
 branches:
   release:
     regex: ^latest$
+    tag: ''
   develop:
     regex: ^((?!latest).)*$
+    tag: 'beta'


### PR DESCRIPTION
**Changelog**

- Dockerfile improvements to make it architecture-aware. 

- Added multi-platform build in the release pipeline. 

- The Makefile new var `MULTIPLATFORM=true` for build. `false` by default.
This will allow Docker images to be built for both `linux/amd64` and `linux/arm64` architectures using Docker Buildx. 

**Successful test release**

- https://github.com/udx/worker/actions/runs/11165941546

- https://hub.docker.com/layers/usabilitydynamics/udx-worker/0.1.0-beta.538/images/sha256-2c379a6f2b319ea5962bd0e294c7746d2f766677c54de53726f77be29399f07b?context=explore

<img width="1900" alt="image" src="https://github.com/user-attachments/assets/b952d6d4-54a6-44aa-a9b2-7c67a75d0ae5">


