### PR TITLE
Supervisor config [UAT-60]

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,21 +1,62 @@
 #!/bin/bash
 
-# Source the utilities script
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source /usr/local/lib/utils.sh
 
 udx_logo
 
-echo "[INFO] Welcome to UDX Worker Container. Initializing environment..."
+log_info "Welcome to UDX Worker Container. Initializing environment..."
 
-# Execute the environment.sh script to set up the environment
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source /usr/local/lib/environment.sh
 
-# If there are arguments, execute them
+handle_services() {
+    local cmd_exit_status=$1  # Pass command exit status if any
+
+    if check_active_services; then
+        wait_for_services
+        log_info "Tailing Supervisor logs to keep the container alive."
+        tail -f /var/log/supervisor/supervisord.log
+    else
+        log_warn "No services are active. Exiting after a short delay."
+        sleep 10
+        exit "${cmd_exit_status:-0}"  # Use 0 if cmd_exit_status is unset
+    fi
+}
+
+check_active_services() {
+    log_info "Checking for active or starting services..."
+    if supervisorctl status | grep -Eq 'RUNNING|STARTING'; then
+        log_info "Active or starting services found."
+        return 0
+    else
+        log_warn "No active or starting services detected."
+        return 1
+    fi
+}
+
+wait_for_services() {
+    local attempts=0 max_attempts=10
+    log_info "Waiting for services to be fully running..."
+    while [ $attempts -lt $max_attempts ]; do
+        if supervisorctl status | grep -q "RUNNING"; then
+            log_info "All services are now running."
+            return 0
+        fi
+        log_info "Waiting for services to be fully running... (Attempt: $attempts)"
+        attempts=$((attempts + 1))
+        sleep 5
+    done
+    log_warn "Services are not fully running after $max_attempts attempts."
+    return 1
+}
+
+# Main execution path
 if [ "$#" -gt 0 ]; then
-    exec "$@"
+    log_info "Executing command:" "$*"
+    "$@"  # Execute the provided command
+    cmd_exit_status=$?
+    handle_services $cmd_exit_status
 else
-    echo "[INFO] No command provided, the container will run interactively."
-    # Add any additional logic here if needed
+    handle_services
 fi

--- a/etc/home/supervisor.common.conf
+++ b/etc/home/supervisor.common.conf
@@ -4,7 +4,7 @@ logfile_maxbytes=50MB
 logfile_backups=10
 loglevel=info
 pidfile=/var/run/supervisor/supervisord.pid
-nodaemon=false
+nodaemon=true
 minfds=1024
 minprocs=200
 

--- a/etc/home/supervisor.common.conf
+++ b/etc/home/supervisor.common.conf
@@ -16,11 +16,3 @@ file=/var/run/supervisor/supervisord.sock  ; path to your socket file
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
-
-[program:${process_name}]
-command=${command}
-autostart=${autostart}
-autorestart=${autorestart}
-stderr_logfile=/var/log/supervisor/${process_name}.err.log
-stdout_logfile=/var/log/supervisor/${process_name}.out.log
-environment=${envs}

--- a/etc/home/supervisor.program.conf
+++ b/etc/home/supervisor.program.conf
@@ -1,0 +1,7 @@
+[program:${process_name}]
+command=${command}
+autostart=${autostart}
+autorestart=${autorestart}
+stderr_logfile=/var/log/supervisor/${process_name}.err.log
+stdout_logfile=/var/log/supervisor/${process_name}.out.log
+environment=${envs}

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -91,10 +91,10 @@ configure_environment() {
     # Perform process manager setup
     log_info "Setting up process manager..."
     if should_generate_config; then
-        echo "Preparing Supervisor configurations..."
+        log_info "Generating Supervisor configuration..."
         configure_and_execute_services
     else
-        echo "No services found in $CONFIG_FILE. Skipping Supervisor configuration."
+        log_info "No services found in the configuration. Skipping process manager setup."
     fi
 
     log_info "Secure environment setup completed successfully."

--- a/lib/process_manager.sh
+++ b/lib/process_manager.sh
@@ -52,7 +52,7 @@ start_supervisor() {
 # Function to configure and start the Supervisor
 configure_and_execute_services() {
     if ! should_generate_config; then
-        echo "No services found in $CONFIG_FILE. Skipping Supervisor configuration."
+        echo "No services found in $CONFIG_FILE. No Supervisor configuration generated."
         return 1
     fi
     

--- a/lib/process_manager.sh
+++ b/lib/process_manager.sh
@@ -2,7 +2,8 @@
 
 # Define paths
 CONFIG_FILE="/etc/worker/services.yml"
-TEMPLATE_FILE="/home/${USER}/etc/supervisor.default"
+COMMON_TEMPLATE_FILE="/home/${USER}/etc/supervisor.common.conf"
+PROGRAM_TEMPLATE_FILE="/home/${USER}/etc/supervisor.program.conf"
 FINAL_CONFIG="/home/${USER}/etc/supervisord.conf"
 
 # Function to check for service configurations
@@ -32,11 +33,14 @@ parse_service_info() {
     autorestart=$(echo "$service_json" | jq -r '.autorestart // "false"')
     environment=$(echo "$service_json" | jq -r '.environment // [] | join(",")')
     
+    # Add an additional newline for better separation and readability
+    echo -e "\n" >> "$FINAL_CONFIG"  # Adds two newlines to the end of the file
+    
     sed "s|\${process_name}|$name|g; \
         s|\${command}|$command|g; \
         s|\${autostart}|$autostart|g; \
         s|\${autorestart}|$autorestart|g; \
-        s|\${envs}|$environment|g" "$TEMPLATE_FILE" >> "$FINAL_CONFIG"
+        s|\${envs}|$environment|g" "$PROGRAM_TEMPLATE_FILE" >> "$FINAL_CONFIG"
 }
 
 # Function to start Supervisor with the generated configuration
@@ -52,16 +56,11 @@ configure_and_execute_services() {
         return 1
     fi
     
-    # Copy the base Supervisor configuration.
-    cp "$TEMPLATE_FILE" "$FINAL_CONFIG"
-    
-    # Remove the template [program:x] section from FINAL_CONFIG
-    # shellcheck disable=SC2016
-    sed -i '/\[program:\${process_name}\]/,/^$/d' "$FINAL_CONFIG"
+    # Copy the base Supervisor common configuration only once at the start.
+    cp "$COMMON_TEMPLATE_FILE" "$FINAL_CONFIG"
     
     # Convert enabled services to JSON and process each.
     local services_yaml
-    # Filter only services with enabled: true
     services_yaml=$(yq e -o=json '.services[] | select(.enabled == true)' "$CONFIG_FILE" | jq -c .)
     
     if [ -z "$services_yaml" ]; then
@@ -69,16 +68,7 @@ configure_and_execute_services() {
         return 1
     fi
     
-    # Use a temporary file to avoid subshell issues
-    local services_file
-    services_file=$(mktemp)
-    
-    echo "$services_yaml" > "$services_file"
-    mapfile -t services_array < "$services_file"
-    rm -f "$services_file"
-    
-    # Process each service in the array
-    for service_json in "${services_array[@]}"; do
+    echo "$services_yaml" | while read -r service_json; do
         parse_service_info "$service_json"
     done
     


### PR DESCRIPTION
## Changes

- Improved entrypoint to handle different scenarios
- Split supervisor config for common and app-level configurations
- `lib/process_manager.sh` module updates

### Generated `supervisord` config with 2 processes defined

```
$ cat /home/udx/etc/supervisord.conf

[supervisord]
logfile=/var/log/supervisor/supervisord.log
logfile_maxbytes=50MB
logfile_backups=10
loglevel=info
pidfile=/var/run/supervisor/supervisord.pid
nodaemon=false
minfds=1024
minprocs=200

[supervisorctl]
serverurl=unix:///var/run/supervisor/supervisord.sock

[unix_http_server]
file=/var/run/supervisor/supervisord.sock  ; path to your socket file

[rpcinterface:supervisor]
supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

[program:app_service]
command=sh /usr/local/scripts/process_example.sh
autostart=true
autorestart=false
stderr_logfile=/var/log/supervisor/app_service.err.log
stdout_logfile=/var/log/supervisor/app_service.out.log
environment=KEY1=value1,KEY2=value2

[program:another_service]
command=sh /usr/local/scripts/process_example.sh
autostart=true
autorestart=true
stderr_logfile=/var/log/supervisor/another_service.err.log
stdout_logfile=/var/log/supervisor/another_service.out.log
environment=
```

### Entrypoint with no processes enabled

```
2025-01-06 14:21:33                _                          _              
2025-01-06 14:21:33               | |                        | |             
2025-01-06 14:21:33      _   _  __| |_  ____      _____  _ __| | _____ _ __  
2025-01-06 14:21:33     | | | |/ _` \ \/ /\ \ /\ / / _ \| '__| |/ / _ \ '__| 
2025-01-06 14:21:33     | |_| | (_| |>  < _\ V  V / (_) | |  |   <  __/ |    
2025-01-06 14:21:33      \__,_|\__,_/_/\_(_)\_/\_/ \___/|_|  |_|\_\___|_|    
2025-01-06 14:21:33 [INFO] Welcome to UDX Worker Container. Initializing environment...
2025-01-06 14:21:33 [INFO] Starting environment configuration...
2025-01-06 14:21:33 [INFO] Merging worker configurations...
2025-01-06 14:21:33 [INFO] No user configuration provided. Using built-in configuration only.
2025-01-06 14:21:33 [INFO] Worker configuration loaded successfully.
2025-01-06 14:21:33 [INFO] Exporting variables from configuration to environment...
2025-01-06 14:21:33 [INFO] Exporting variables from configuration...
2025-01-06 14:21:33 [INFO] Authenticating actors from configuration...
2025-01-06 14:21:33 [INFO] Skipping gcp authentication as no credentials were provided.
2025-01-06 14:21:33 [INFO] Skipping azure authentication as no credentials were provided.
2025-01-06 14:21:33 [INFO] Skipping aws authentication as no credentials were provided.
2025-01-06 14:21:33 [INFO] Skipping bitwarden authentication as no credentials were provided.
2025-01-06 14:21:33 [INFO] No secrets defined in the configuration.
2025-01-06 14:21:33 [INFO] Cleaning up sensitive data...
2025-01-06 14:21:33 [INFO] Starting cleanup of actors
2025-01-06 14:21:33 [INFO] No active sessions found for any configured providers.
2025-01-06 14:21:33 [INFO] Cleaning up sensitive environment variables
2025-01-06 14:21:33 [INFO] Sensitive environment variables cleaned up successfully.
2025-01-06 14:21:33 [INFO] Setting up process manager...
2025-01-06 14:21:33 [INFO] No services found in the configuration. Skipping process manager setup.
2025-01-06 14:21:33 [INFO] Secure environment setup completed successfully.
2025-01-06 14:21:33 [INFO] Executing command: sh
2025-01-06 14:21:33 [INFO] Checking for active or starting services...
2025-01-06 14:21:33 [WARN] No active or starting services detected.
2025-01-06 14:21:33 [WARN] No services are active. Exiting after a short delay.
```

### Entrypoint with process defined

```
2025-01-06 14:33:13                _                          _              
2025-01-06 14:33:13               | |                        | |             
2025-01-06 14:33:13      _   _  __| |_  ____      _____  _ __| | _____ _ __  
2025-01-06 14:33:13     | | | |/ _` \ \/ /\ \ /\ / / _ \| '__| |/ / _ \ '__| 
2025-01-06 14:33:13     | |_| | (_| |>  < _\ V  V / (_) | |  |   <  __/ |    
2025-01-06 14:33:13      \__,_|\__,_/_/\_(_)\_/\_/ \___/|_|  |_|\_\___|_|    
2025-01-06 14:33:13 [INFO] Welcome to UDX Worker Container. Initializing environment...
2025-01-06 14:33:13 [INFO] Starting environment configuration...
2025-01-06 14:33:13 [INFO] Merging worker configurations...
2025-01-06 14:33:13 [INFO] No user configuration provided. Using built-in configuration only.
2025-01-06 14:33:14 [INFO] Worker configuration loaded successfully.
2025-01-06 14:33:14 [INFO] Exporting variables from configuration to environment...
2025-01-06 14:33:14 [INFO] Exporting variables from configuration...
2025-01-06 14:33:14 [INFO] Authenticating actors from configuration...
2025-01-06 14:33:14 [INFO] Skipping gcp authentication as no credentials were provided.
2025-01-06 14:33:14 [INFO] Skipping azure authentication as no credentials were provided.
2025-01-06 14:33:14 [INFO] Skipping aws authentication as no credentials were provided.
2025-01-06 14:33:14 [INFO] Skipping bitwarden authentication as no credentials were provided.
2025-01-06 14:33:14 [INFO] No secrets defined in the configuration.
2025-01-06 14:33:14 [INFO] Cleaning up sensitive data...
2025-01-06 14:33:14 [INFO] Starting cleanup of actors
2025-01-06 14:33:14 [INFO] No active sessions found for any configured providers.
2025-01-06 14:33:14 [INFO] Cleaning up sensitive environment variables
2025-01-06 14:33:14 [INFO] Sensitive environment variables cleaned up successfully.
2025-01-06 14:33:14 [INFO] Setting up process manager...
2025-01-06 14:33:14 [INFO] Generating Supervisor configuration...
2025-01-06 14:33:14 Starting Supervisor with the generated configuration...
2025-01-06 14:33:15 2025-01-06 12:33:15,711 INFO RPC interface 'supervisor' initialized
2025-01-06 14:33:15 2025-01-06 12:33:15,711 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2025-01-06 14:33:15 2025-01-06 12:33:15,713 INFO supervisord started with pid 128
2025-01-06 14:33:16 2025-01-06 12:33:16,719 INFO spawned: 'app_service' with pid 129
2025-01-06 14:33:17 2025-01-06 12:33:17,742 INFO success: app_service entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-01-06 14:33:47 2025-01-06 12:33:47,029 INFO exited: app_service (exit status 0; expected)
```