### PR TITLE
Security Enhancements & Package Updates [1629]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
     tzdata=2024b-6ubuntu1 \
     curl=8.11.1-1ubuntu1 \
     bash=5.2.37-1ubuntu1 \
-    apt-utils=2.9.18 \
+    apt-utils=2.9.28 \
     gettext=0.23.1-1 \
     gnupg=2.4.4-2ubuntu22 \
     ca-certificates=20241223 \
@@ -35,7 +35,7 @@ RUN apt-get update && \
     unzip=6.0-28ubuntu6 \
     nano=8.3-1 \
     vim=2:9.1.0861-1ubuntu1 \
-    python3.12=3.12.8-5 \
+    python3.12=3.12.9-1 \
     python3-pip=25.0+dfsg-1 \
     supervisor=4.2.5-3 && \
     apt-get clean && \
@@ -104,7 +104,10 @@ RUN ARCH=$(uname -m) && \
 
 # Create a new user and group with specific UID and GID, and set permissions
 RUN groupadd -g ${GID} ${USER} && \
-    useradd -l -m -u ${UID} -g ${GID} -s /bin/bash ${USER}
+    useradd -l -m -u ${UID} -g ${GID} -s /bin/bash ${USER} && \
+    mkdir -p /etc/sudoers.d && \
+    echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER} && \
+    chmod 0440 /etc/sudoers.d/${USER}
 
 # Create the Supervisor log directory and set permissions
 RUN mkdir -p /var/log/supervisor /var/run/supervisor && \
@@ -123,7 +126,10 @@ COPY bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Set permissions during build
 RUN chmod +x /usr/local/bin/entrypoint.sh && \
-    chown -R ${UID}:${GID} /usr/local/configs
+    chown -R ${UID}:${GID} /usr/local/configs && \
+    chown -R ${UID}:${GID} /usr/local/bin && \
+    chown -R ${UID}:${GID} /usr/local/lib && \
+    chmod -R g-w,o-w /usr/local/configs /usr/local/bin /usr/local/lib
 
 # Create a symbolic link for the supervisord configuration file
 RUN ln -sf /usr/local/configs/supervisor/supervisord.conf /etc/supervisord.conf    

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,10 +104,7 @@ RUN ARCH=$(uname -m) && \
 
 # Create a new user and group with specific UID and GID, and set permissions
 RUN groupadd -g ${GID} ${USER} && \
-    useradd -l -m -u ${UID} -g ${GID} -s /bin/bash ${USER} && \
-    mkdir -p /etc/sudoers.d && \
-    echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER} && \
-    chmod 0440 /etc/sudoers.d/${USER}
+    useradd -l -m -u ${UID} -g ${GID} -s /bin/bash ${USER}
 
 # Create the Supervisor log directory and set permissions
 RUN mkdir -p /var/log/supervisor /var/run/supervisor && \

--- a/docs/git-help.md
+++ b/docs/git-help.md
@@ -42,3 +42,32 @@ git push -f
 - `-f` or `--force`: This option forces Git to push the amended commit to the remote repository, rewriting history.
 
 > Note: Force pushing can overwrite changes in the remote repository, so use it carefully, especially when working in a shared environment.
+
+### 4. Moving Unpushed Commits Between Branches
+
+If you need to move an unpushed commit from one branch to another, you can use git cherry-pick. Here's an example of moving a commit from branch `UAT-69` to branch `1629`:
+
+1. First, identify the unpushed commit on the source branch:
+```shell
+git log UAT-69 --not --remotes --oneline
+```
+
+2. Note the commit hash from the output (e.g., `4cff367`)
+
+3. Switch to the target branch and stash any current changes:
+```shell
+git checkout 1629
+git stash  # if you have uncommitted changes
+```
+
+4. Cherry-pick the commit:
+```shell
+git cherry-pick 4cff367
+```
+
+5. Restore your stashed changes if any:
+```shell
+git stash pop
+```
+
+> Note: The cherry-pick command creates a new commit on the target branch with the same changes but a different commit hash.

--- a/lib/secrets/gcp.sh
+++ b/lib/secrets/gcp.sh
@@ -27,7 +27,11 @@ resolve_gcp_secret() {
         return 1
     fi
 
-    # Output only the secret value
-    printf "%s" "$secret_value"
+    # For multiline secrets (like private keys), base64 encode them
+    if [[ "$secret_value" == *"-----BEGIN"* ]] || [[ "$secret_value" == *$'\n'* ]]; then
+        printf "%s" "$secret_value" | base64
+    else
+        printf "%s" "$secret_value"
+    fi
     return 0
 }


### PR DESCRIPTION
### Enhancements 
- Set proper ownership for critical directories (`/usr/local/{configs,bin,lib}`)
- Remove write permissions for group/others on critical paths
- Add base64 encoding for multiline GCP secrets (e.g. private keys)

### Package Updates
- `apt-utils`: 2.9.18 → 2.9.28
- `python3.12`: 3.12.8-5 → 3.12.9-1

### Documentation
- Added git guide for moving commits between branches using `cherry-pick`

Changes improve container security, secrets handling, and keep core packages up to date.