### PR TITLE
Google Cloud Credentials Environment Improvements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install ShellCheck
         run: sudo apt-get install -y shellcheck
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install hadolint
         run: |
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install yamllint
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
           driver: docker-container
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.0.1
+        uses: gittools/actions/gitversion/setup@v4.1.0
         with:
           versionSpec: "6.1.0"
 
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -141,7 +141,7 @@ jobs:
           git config --global user.name "UDX Worker"
 
       - name: Download SBOM Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: sbom
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist/
 
 # Ignore Prettier configuration overrides for development
 .prettierignore
+
+# Configuration files
+.config

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     WORKER_BIN_DIR=/usr/local/worker/bin \
     WORKER_ETC_DIR=/usr/local/worker/etc \
     # Add worker bin to PATH
-    PATH=/usr/local/worker/bin:${PATH} 
+    PATH=/usr/local/worker/bin:${PATH} \
+    # Default envs
+    ACTORS_CLEANUP=false
 
 # Set the shell with pipefail option
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     WORKER_BIN_DIR=/usr/local/worker/bin \
     WORKER_ETC_DIR=/usr/local/worker/etc \
     # Add worker bin to PATH
-    PATH=/usr/local/worker/bin:${PATH} \
-    # Default envs
-    ACTORS_CLEANUP=false
+    PATH=/usr/local/worker/bin:${PATH}
 
 # Set the shell with pipefail option
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,17 +20,18 @@ ENV DEBIAN_FRONTEND=noninteractive \
     WORKER_BIN_DIR=/usr/local/worker/bin \
     WORKER_ETC_DIR=/usr/local/worker/etc \
     # Add worker bin to PATH
-    PATH=/usr/local/worker/bin:${PATH} \
-    # Cloud SDK configurations
-    CLOUDSDK_CONFIG=/usr/local/configs/gcloud \
-    AWS_CONFIG_FILE=/usr/local/configs/aws \
-    AZURE_CONFIG_DIR=/usr/local/configs/azure
+    PATH=/usr/local/worker/bin:${PATH} 
 
 # Set the shell with pipefail option
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Set user to root for installation
 USER root
+
+# Set config paths
+ENV AWS_CONFIG_FILE=${HOME}/.config/aws
+ENV AZURE_CONFIG_DIR=${HOME}/.config/azure
+ENV CLOUDSDK_CONFIG=${HOME}/.config/gcloud
 
 # Install necessary packages
 # hadolint ignore=DL3015
@@ -49,8 +50,8 @@ RUN apt-get update && \
     unzip=6.0-28ubuntu6 \
     nano=8.3-1 \
     vim=2:9.1.0967-1ubuntu4 \
-    python3.13=3.13.3-1ubuntu0.2 \
-    python3.13-venv=3.13.3-1ubuntu0.2 \
+    python3.13=3.13.3-1ubuntu0.3 \
+    python3.13-venv=3.13.3-1ubuntu0.3 \
     python3-pip=25.0+dfsg-1ubuntu0.1 \
     supervisor=4.2.5-3 && \
     # Install Azure CLI in venv with optimizations for scanning
@@ -75,12 +76,11 @@ RUN echo $TZ > /etc/timezone && \
 # Install yq (architecture-aware)
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
-    curl -sL https://github.com/mikefarah/yq/releases/download/v4.47.1/yq_linux_${ARCH}.tar.gz | tar xz && \
+    curl -sL https://github.com/mikefarah/yq/releases/download/v4.47.2/yq_linux_${ARCH}.tar.gz | tar xz && \
     mv yq_linux_${ARCH} /usr/bin/yq && \
     rm -rf /tmp/*
 
 # Install Google Cloud SDK (architecture-aware)
-ENV CLOUDSDK_CONFIG=/usr/local/configs/gcloud
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
     curl -sSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-532.0.0-linux-x86_64.tar.gz" -o google-cloud-sdk.tar.gz; \
@@ -95,7 +95,6 @@ RUN ARCH=$(uname -m) && \
 ENV PATH=$PATH:/google-cloud-sdk/bin
 
 # Install AWS CLI (architecture-aware)
-ENV AWS_CONFIG_FILE=/usr/local/configs/aws
 RUN ARCH=$(uname -m) && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
@@ -136,9 +135,10 @@ RUN mkdir -p \
     # User and config directories
     ${HOME}/.config/worker \
     # Cloud SDK config directories
-    ${CLOUDSDK_CONFIG} \
-    ${AWS_CONFIG_FILE%/*} \
-    ${AZURE_CONFIG_DIR} && \
+    ${HOME}/.config/gcloud \
+    ${HOME}/.config/gcloud/credentials \
+    ${HOME}/.config/aws \
+    ${HOME}/.config/azure && \
     # Create and set permissions for environment files
     touch ${WORKER_CONFIG_DIR}/environment && \
     chown ${USER}:${USER} ${WORKER_CONFIG_DIR}/environment && \
@@ -168,13 +168,12 @@ RUN \
         ${WORKER_LIB_DIR} \
         ${WORKER_BIN_DIR} \
         ${HOME} \
-        ${CLOUDSDK_CONFIG} \
-        ${AWS_CONFIG_FILE%/*} \
-        ${AZURE_CONFIG_DIR} \
         /opt/az && \
     # Set Azure CLI permissions
     chmod -R 755 /opt/az/bin && \
-    chmod -R 700 ${AZURE_CONFIG_DIR} && \
+    # Set cloud config directory permissions
+    chmod -R 700 ${HOME}/.config/gcloud/credentials && \
+    chmod -R 700 ${HOME}/.config/azure && \
     # Set directory permissions
     find ${WORKER_BASE_DIR} ${WORKER_CONFIG_DIR} ${WORKER_LIB_DIR} ${WORKER_BIN_DIR} -type d -exec chmod 755 {} + && \
     # Set base file permissions

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -6,22 +6,22 @@ The UDX Worker supports multiple cloud providers and services through environmen
 
 ## Supported Providers
 
-| Provider   | Environment Variable  | Description |
-|------------|---------------------|-------------|
-| Azure      | `AZURE_CREDS`      | Azure cloud credentials |
-| AWS        | `AWS_CREDS`        | Amazon Web Services credentials |
-| GCP        | `GCP_CREDS`        | Google Cloud Platform credentials |
-| Bitwarden  | `BITWARDEN_CREDS`  | Bitwarden secrets management credentials |
+| Provider  | Environment Variable | Description                              |
+| --------- | -------------------- | ---------------------------------------- |
+| Azure     | `AZURE_CREDS`        | Azure cloud credentials                  |
+| AWS       | `AWS_CREDS`          | Amazon Web Services credentials          |
+| GCP       | `GCP_CREDS`          | Google Cloud Platform credentials        |
+| Bitwarden | `BITWARDEN_CREDS`    | Bitwarden secrets management credentials |
 
 ## Credential Formats
 
 Credentials can be provided in three formats:
 
-| Format | Description | Use Case |
-|--------|-------------|----------|
-| JSON | Plain JSON string | Direct configuration |
-| Base64 | Base64-encoded JSON | Secure environment variables |
-| File Path | Path to JSON file | Local development |
+| Format    | Description         | Use Case                     |
+| --------- | ------------------- | ---------------------------- |
+| JSON      | Plain JSON string   | Direct configuration         |
+| Base64    | Base64-encoded JSON | Secure environment variables |
+| File Path | Path to JSON file   | Local development            |
 
 ## Format Examples
 
@@ -29,10 +29,10 @@ Credentials can be provided in three formats:
 
 ```json
 {
-    "client_id": "CLIENT_ID",
-    "client_secret": "CLIENT_SECRET",
-    "tenant_id": "TENANT_ID",
-    "subscription_id": "SUBSCRIPTION_ID"
+  "client_id": "CLIENT_ID",
+  "client_secret": "CLIENT_SECRET",
+  "tenant_id": "TENANT_ID",
+  "subscription_id": "SUBSCRIPTION_ID"
 }
 ```
 
@@ -52,6 +52,7 @@ ewogICAgImNsaWVudF9pZCI6ICJDTElFTlRfSUQiLAogICAgImNsaWVudF9zZWNyZXQiOiAiQ0xJRU5U
 ```
 
 **Generate Base64 Format:**
+
 ```bash
 echo -n '{"client_id":"CLIENT_ID","client_secret":"CLIENT_SECRET","tenant_id":"TENANT_ID","subscription_id":"SUBSCRIPTION_ID"}' | base64
 ```
@@ -72,3 +73,14 @@ AZURE_CREDS="/path/to/azure_credentials.json"
 ```
 
 > **Note**: Always use absolute paths in production environments to avoid path resolution issues.
+
+## Credential Management
+
+| Flag             | Default | Description                                                               |
+| ---------------- | ------- | ------------------------------------------------------------------------- |
+| `ACTORS_CLEANUP` | `true`  | Controls how cloud provider credentials are handled after authentication: |
+
+- When `true` (default): All temporary credentials and login sessions are cleaned up after use, improving security by not leaving credentials on disk
+- When `false`: Credentials are preserved on disk for reuse (e.g., GCP credentials are stored at `$HOME/creds/gcp_creds.json` and `GOOGLE_APPLICATION_CREDENTIALS` is set)
+
+This flag is particularly useful for long-running processes or development environments where frequent re-authentication would be inefficient.

--- a/lib/auth/gcp.sh
+++ b/lib/auth/gcp.sh
@@ -44,8 +44,12 @@ gcp_authenticate() {
     jq -n --arg clientEmail "$clientEmail" --arg privateKey "$privateKey" --arg projectId "$projectId" \
     '{client_email: $clientEmail, private_key: $privateKey, project_id: $projectId}' > "$temp_creds_file"
 
-    # Set GOOGLE_APPLICATION_CREDENTIALS if ACTORS_CLEANUP is false
-    if [ "$ACTORS_CLEANUP" = false ]; then
+    # Set GOOGLE_APPLICATION_CREDENTIALS based on conditions
+    if [ -f "$GCP_CREDS" ]; then
+        # If GCP_CREDS is a file path and exists, use it directly
+        export GOOGLE_APPLICATION_CREDENTIALS="$GCP_CREDS"
+    elif [ "$ACTORS_CLEANUP" = false ]; then
+        # Otherwise, if ACTORS_CLEANUP is false, create and use a local copy
         mkdir -p "$HOME/creds"
         cat "$creds_json" > "$HOME/creds/gcp_creds.json"
         export GOOGLE_APPLICATION_CREDENTIALS="$HOME/creds/gcp_creds.json"

--- a/lib/auth/gcp.sh
+++ b/lib/auth/gcp.sh
@@ -47,7 +47,7 @@ gcp_authenticate() {
     # Set GOOGLE_APPLICATION_CREDENTIALS if ACTORS_CLEANUP is false
     if [ "$ACTORS_CLEANUP" = false ]; then
         mkdir -p "$HOME/creds"
-        echo $creds_content > "$HOME/creds/gcp_creds.json"
+        cat "$creds_json" > "$HOME/creds/gcp_creds.json"
         export GOOGLE_APPLICATION_CREDENTIALS="$HOME/creds/gcp_creds.json"
     fi
     

--- a/lib/auth/gcp.sh
+++ b/lib/auth/gcp.sh
@@ -43,6 +43,13 @@ gcp_authenticate() {
     # Use jq to create a valid JSON with the modified privateKey
     jq -n --arg clientEmail "$clientEmail" --arg privateKey "$privateKey" --arg projectId "$projectId" \
     '{client_email: $clientEmail, private_key: $privateKey, project_id: $projectId}' > "$temp_creds_file"
+
+    # Set GOOGLE_APPLICATION_CREDENTIALS if ACTORS_CLEANUP is false
+    if [ "$ACTORS_CLEANUP" = false ]; then
+        mkdir -p "$HOME/creds"
+        echo $creds_content > "$HOME/creds/gcp_creds.json"
+        export GOOGLE_APPLICATION_CREDENTIALS="$HOME/creds/gcp_creds.json"
+    fi
     
     log_info "GCP Authentication" "Authenticating GCP service account..."
     if ! gcloud auth activate-service-account "$clientEmail" --key-file="$temp_creds_file" >/dev/null 2>&1; then

--- a/lib/auth/gcp.sh
+++ b/lib/auth/gcp.sh
@@ -44,15 +44,17 @@ gcp_authenticate() {
     jq -n --arg clientEmail "$clientEmail" --arg privateKey "$privateKey" --arg projectId "$projectId" \
     '{client_email: $clientEmail, private_key: $privateKey, project_id: $projectId}' > "$temp_creds_file"
 
-    # Set GOOGLE_APPLICATION_CREDENTIALS based on conditions
-    if [ -f "$GCP_CREDS" ]; then
-        # If GCP_CREDS is a file path and exists, use it directly
-        export GOOGLE_APPLICATION_CREDENTIALS="$GCP_CREDS"
-    elif [ "$ACTORS_CLEANUP" = false ]; then
-        # Otherwise, if ACTORS_CLEANUP is false, create and use a local copy
-        mkdir -p "$HOME/creds"
-        cat "$creds_json" > "$HOME/creds/gcp_creds.json"
-        export GOOGLE_APPLICATION_CREDENTIALS="$HOME/creds/gcp_creds.json"
+    # Set GOOGLE_APPLICATION_CREDENTIALS only if ACTORS_CLEANUP is disabled
+    if [ "$ACTORS_CLEANUP" = false ]; then
+        if [ -f "$GCP_CREDS" ]; then
+            # If GCP_CREDS is a file path and exists, use it directly
+            export GOOGLE_APPLICATION_CREDENTIALS="$GCP_CREDS"
+        else
+            # Otherwise create and use a local copy
+            mkdir -p "$HOME/creds"
+            cat "$creds_json" > "$HOME/creds/gcp_creds.json"
+            export GOOGLE_APPLICATION_CREDENTIALS="$HOME/creds/gcp_creds.json"
+        fi
     fi
     
     log_info "GCP Authentication" "Authenticating GCP service account..."

--- a/lib/cleanup.sh
+++ b/lib/cleanup.sh
@@ -7,9 +7,6 @@ source "${WORKER_LIB_DIR}/worker_config.sh"
 # shellcheck source=/dev/null
 source "${WORKER_LIB_DIR}/utils.sh"
 
-# Enable actors cleanup by default
-ACTORS_CLEANUP=${ACTORS_CLEANUP:-true}
-
 # Generic function to clean up authentication for any provider
 cleanup_provider() {
     local provider=$1

--- a/lib/cli/config.sh
+++ b/lib/cli/config.sh
@@ -52,8 +52,6 @@ config_show() {
         esac
         i=$((i + 1))
     done
-
-    log_info "Config" "Current configuration:"
     
     # Check if user config exists
     if [ ! -f "$USER_CONFIG" ] || [ ! -s "$USER_CONFIG" ]; then

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -31,6 +31,11 @@ configure_environment() {
         return 1
     fi
 
+    # Set default envs
+    if [[ -z "${ACTORS_CLEANUP:-}" ]]; then
+        export ACTORS_CLEANUP=true
+    fi
+
     # Extract and authenticate actors
     local actors
     actors=$(get_config_section "$resolved_config" "actors")


### PR DESCRIPTION
Successful build and test: https://github.com/udx/worker/actions/runs/17619718883

## Changes

### GCP Authentication Improvements
- Added support for persistent Google Cloud credentials via `GOOGLE_APPLICATION_CREDENTIALS` environment variable
- Reorganized cloud provider configuration paths to use standard locations under `$HOME/.config/`

### Dependency Updates
- Updated Python packages to version `3.13.3-1ubuntu0.3`
- Upgraded YQ to `v4.47.2`
- Updated GitHub Actions dependencies:
  - actions/checkout from `v4` to `v5`
  - actions/download-artifact from `v4` to `v5`
  - gittools/actions/gitversion/setup from `v4.0.1` to `v4.1.0`