### PR TITLE
Fix glcoud logs permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v4.0.1
+        uses: gittools/actions/gitversion/execute@v4.1.0
         with:
           useConfigFile: true
           configFilePath: ci/git-version.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,7 @@ RUN mkdir -p \
     # Cloud SDK config directories
     ${HOME}/.config/gcloud \
     ${HOME}/.config/gcloud/credentials \
+    ${HOME}/.config/gcloud/logs \
     ${HOME}/.config/aws \
     ${HOME}/.config/azure && \
     # Create and set permissions for environment files
@@ -173,6 +174,7 @@ RUN \
     chmod -R 755 /opt/az/bin && \
     # Set cloud config directory permissions
     chmod -R 700 ${HOME}/.config/gcloud/credentials && \
+    chmod -R 755 ${HOME}/.config/gcloud/logs && \
     chmod -R 700 ${HOME}/.config/azure && \
     # Set directory permissions
     find ${WORKER_BASE_DIR} ${WORKER_CONFIG_DIR} ${WORKER_LIB_DIR} ${WORKER_BIN_DIR} -type d -exec chmod 755 {} + && \


### PR DESCRIPTION
Fix the following warning

```
WARNING: Could not setup log file in /home/udx/.config/gcloud/logs, (PermissionError: [Errno 13] Permission denied: '/home/udx/.config/gcloud/logs/2025.09.11/12.32.51.068340.log'.
The configuration directory may not be writable. To learn more, see https://cloud.google.com/sdk/docs/configurations#creating_a_configuration
```