### PR TITLE
Improve GCP Authentication with Application Default Credentials

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -100,7 +100,7 @@ jobs:
           jq -r '.packages[] | select(.versionInfo != null) | "\(.name) | \(.versionInfo)"' sbom.json | sort | uniq | head -n 20 | column -t -s '|'
 
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sbom
           path: sbom.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
           fi
 
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sbom
           path: sbom.json
@@ -141,7 +141,7 @@ jobs:
           git config --global user.name "UDX Worker"
 
       - name: Download SBOM Artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: sbom
 

--- a/lib/auth.sh
+++ b/lib/auth.sh
@@ -79,6 +79,10 @@ authenticate_actors() {
     
     mapfile -t actors_array < "$actors_file"
     rm -f "$actors_file"
+
+    # Create local creds dir
+    log_info "Pre-creating local creds dir"
+    mkdir -p "$LOCAL_CREDS_DIR"
     
     for actor in "${actors_array[@]}"; do
         local type provider creds auth_script auth_function

--- a/lib/auth/gcp.sh
+++ b/lib/auth/gcp.sh
@@ -3,13 +3,14 @@
 # shellcheck source=${WORKER_LIB_DIR}/utils.sh disable=SC1091
 source "${WORKER_LIB_DIR}/utils.sh"
 
-# Function to authenticate GCP service accounts
+# Function to set ADC credentials
 #
 # Example usage of the function
 # gcp_authenticate "/path/to/your/gcp_creds.json"
+# gcp_authenticate "${GCP_CREDS}"
 #
 
-# Function to authenticate GCP service accounts
+# Function to set ADC credentials
 gcp_authenticate() {
     local creds_json="$1"
     
@@ -20,6 +21,12 @@ gcp_authenticate() {
     if [[ -z "$creds_content" ]]; then
         log_error "GCP Authentication" "No GCP credentials provided."
         return 1
+    fi
+    
+    # If GOOGLE_APPLICATION_CREDENTIALS already set, do not override
+    if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+        log_info "GCP Authentication" "GOOGLE_APPLICATION_CREDENTIALS already set, skipping authentication."
+        return 0
     fi
     
     # Extract necessary fields from the JSON credentials
@@ -34,44 +41,31 @@ gcp_authenticate() {
         return 1
     fi
     
-    # Adjust privateKey formatting
-    # Replace "\\n" with actual new line, handle BEGIN and END markers
-    privateKey=$(echo "$privateKey" | sed 's/\\n/\n/g' | sed 's/- /\n-/g' | sed 's/ -/-\n/g')
-    
-    # Create a temporary credentials file for gcloud authentication
-    local temp_creds_file="/tmp/gcp_creds.json"
-    # Use jq to create a valid JSON with the modified privateKey
-    jq -n --arg clientEmail "$clientEmail" --arg privateKey "$privateKey" --arg projectId "$projectId" \
-    '{client_email: $clientEmail, private_key: $privateKey, project_id: $projectId}' > "$temp_creds_file"
-
-    # Set GOOGLE_APPLICATION_CREDENTIALS only if ACTORS_CLEANUP is disabled
-    if [ "$ACTORS_CLEANUP" = false ]; then
-        if [ -f "$GCP_CREDS" ]; then
-            # If GCP_CREDS is a file path and exists, use it directly
-            export GOOGLE_APPLICATION_CREDENTIALS="$GCP_CREDS"
-        else
-            # Otherwise create and use a local copy
-            mkdir -p "$HOME/creds"
-            cat "$creds_json" > "$HOME/creds/gcp_creds.json"
-            export GOOGLE_APPLICATION_CREDENTIALS="$HOME/creds/gcp_creds.json"
-        fi
+    if [ -f "$GCP_CREDS" ]; then
+        # If GCP_CREDS is a file path and exists, use it directly
+        export GOOGLE_APPLICATION_CREDENTIALS="$GCP_CREDS"
+    else
+        
+        # Adjust privateKey formatting
+        # Replace "\\n" with actual new line, handle BEGIN and END markers
+        privateKey=$(echo "$privateKey" | sed 's/\\n/\n/g' | sed 's/- /\n-/g' | sed 's/ -/-\n/g')
+        
+        jq -n --arg clientEmail "$clientEmail" --arg privateKey "$privateKey" --arg projectId "$projectId" \
+        '{type: "service_account", client_email: $clientEmail, private_key: $privateKey, project_id: $projectId}' > "$LOCAL_CREDS_DIR/gcp_creds.json"
+        
+        export GOOGLE_APPLICATION_CREDENTIALS="$LOCAL_CREDS_DIR/gcp_creds.json"
     fi
     
-    log_info "GCP Authentication" "Authenticating GCP service account..."
-    if ! gcloud auth activate-service-account "$clientEmail" --key-file="$temp_creds_file" >/dev/null 2>&1; then
-        log_error "GCP Authentication" "GCP service account authentication failed."
-        rm -f "$temp_creds_file"
-        return 1
+    # If GOOGLE_APPLICATION_CREDENTIALS is set, authorize environment with provided credentials
+    if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+        log_info "GCP Authentication" "Authorizing environment with provided credentials."
+        gcloud auth login --cred-file="$GOOGLE_APPLICATION_CREDENTIALS" > /dev/null 2>&1
     fi
     
     if ! gcloud config set project "$projectId" >/dev/null 2>&1; then
         log_error "GCP Authentication" "Failed to set GCP project."
-        rm -f "$temp_creds_file"
         return 1
     fi
     
     log_success "GCP Authentication" "GCP service account authenticated and project set."
-    
-    # Clean up temporary credentials file
-    rm -f "$temp_creds_file"
 }

--- a/lib/cleanup.sh
+++ b/lib/cleanup.sh
@@ -122,7 +122,7 @@ cleanup_actors() {
                 fi
                 ;;
             gcp)
-                if cleanup_provider "gcloud" "gcloud auth revoke --all" "gcloud auth list" "GCP"; then
+                if cleanup_provider "gcloud" "gcloud auth revoke --all && unset GOOGLE_APPLICATION_CREDENTIALS" "gcloud auth list" "GCP"; then
                     any_cleanup=true
                 fi
                 ;;
@@ -145,6 +145,12 @@ cleanup_actors() {
     # Log a summary if no cleanup actions were needed
     if [[ "$any_cleanup" == false ]]; then
         log_info "No active sessions found for any configured providers."
+    fi
+
+    # Remove local copy creds dir
+    if [ -d "$LOCAL_CREDS_DIR" ]; then
+        log_info "Removing local copy creds dir"
+        rm -rf "$LOCAL_CREDS_DIR"
     fi
     
     # Clear the configured providers array

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -36,6 +36,10 @@ configure_environment() {
         export ACTORS_CLEANUP=true
     fi
 
+    if [[ -z "${LOCAL_CREDS_DIR:-}" ]]; then
+        export LOCAL_CREDS_DIR="$HOME/.config/worker/creds"
+    fi
+
     # Extract and authenticate actors
     local actors
     actors=$(get_config_section "$resolved_config" "actors")


### PR DESCRIPTION
Refactors GCP authentication to use Application Default Credentials (ADC) pattern, simplifying the authentication flow and improving credential lifecycle management.

## Changes

- Switched to Application Default Credentials (ADC) for gcp auth
- Improved cleanup for gcp

Successful build: https://github.com/udx/worker/actions/runs/18869883540

Local test :

<img width="753" height="525" alt="image" src="https://github.com/user-attachments/assets/c73be8e5-4d39-4425-a787-bc73a36a039b" />
