### PR TITLE
Refresh Docker dependencies

### DIFF
--- a/.github/workflows/docker-ops.yml
+++ b/.github/workflows/docker-ops.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
       security-events: write
       id-token: write
-    uses: udx/reusable-workflows/.github/workflows/docker-ops.yml@master
+    uses: udx/reusable-workflows/.github/workflows/docker-ops.yml@fix/docker-ops-nonrelease-auth-guard
     with:
       image_name: usabilitydynamics/udx-worker
       docker_login: usabilitydynamics

--- a/.github/workflows/docker-ops.yml
+++ b/.github/workflows/docker-ops.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
       security-events: write
       id-token: write
-    uses: udx/reusable-workflows/.github/workflows/docker-ops.yml@fix/docker-ops-nonrelease-auth-guard
+    uses: udx/reusable-workflows/.github/workflows/docker-ops.yml@master
     with:
       image_name: usabilitydynamics/udx-worker
       docker_login: usabilitydynamics

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ FROM ubuntu:25.10
 # Set the maintainer of the image
 LABEL maintainer="UDX CAG Team"
 
-ARG AZURE_CLI_VERSION=2.84.0
-ARG PIP_VERSION=25.3
-ARG YQ_VERSION=4.52.4
-ARG GCLOUD_VERSION=561.0.0
+ARG AZURE_CLI_VERSION=2.85.0
+ARG PIP_VERSION=26.0.1
+ARG YQ_VERSION=4.53.2
+ARG GCLOUD_VERSION=565.0.0
 
 # Set base environment variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -42,7 +42,7 @@ USER root
 # hadolint ignore=DL3015
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    tzdata=2025b-3ubuntu1.1  \
+    tzdata=2026a-0ubuntu0.25.10.1  \
     curl=8.14.1-2ubuntu1.2  \
     bash=5.2.37-2ubuntu5  \
     apt-utils=3.1.6ubuntu2 \
@@ -54,7 +54,7 @@ RUN apt-get update && \
     zip=3.0-15ubuntu2 \
     unzip=6.0-28ubuntu7 \
     nano=8.4-1 \
-    vim=2:9.1.0967-1ubuntu6.1 \
+    vim=2:9.1.0967-1ubuntu6.2 \
     python3.13=3.13.7-1ubuntu0.4 \
     python3.13-venv=3.13.7-1ubuntu0.4 \
     supervisor=4.2.5-3 && \


### PR DESCRIPTION
## Summary
- refresh Dockerfile package and tool versions used by the worker image

## Dependency Upgrades
- `Azure CLI`: `2.84.0` -> `2.85.0`
- `pip`: `25.3` -> `26.0.1`
- `yq`: `4.52.4` -> `4.53.2`
- `Google Cloud SDK`: `561.0.0` -> `565.0.0`
- `tzdata`: `2025b-3ubuntu1.1` -> `2026a-0ubuntu0.25.10.1`
- `vim`: `2:9.1.0967-1ubuntu6.1` -> `2:9.1.0967-1ubuntu6.2`

## Validation
- GitHub Actions `CodeQL and Linter Analysis`: passed
- GitHub Actions `Docker Ops`: currently blocked before build by Docker Hub auth in CI