### PR TITLE
Improve Docker dependency PR workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install ShellCheck
         run: sudo apt-get install -y shellcheck
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install hadolint
         run: |
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install yamllint
         run: |

--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -145,6 +145,7 @@ jobs:
 
     permissions:
       contents: write
+      issues: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -20,6 +20,10 @@ env:
   REPORT_PATH: docker-dependency-report.json
   UPDATE_BRANCH: docker-dependency-updates
   PR_TITLE: "chore(deps): docker dependency upgrade"
+  PR_TEAM_REVIEWER: worker
+  PR_LABELS: |-
+    docker
+    dependencies
   PR_AUTO_MERGE: "true"
   PR_MERGE_METHOD: squash
   COMMIT_MESSAGE: "chore(deps): update Docker dependency pins"
@@ -382,6 +386,8 @@ jobs:
           body-path: docker-dependency-pr-body.md
           branch: ${{ needs.config.outputs.update_branch }}
           add-paths: ${{ needs.config.outputs.dockerfile }}
+          labels: ${{ env.PR_LABELS }}
+          team-reviewers: ${{ env.PR_TEAM_REVIEWER }}
           draft: false
           delete-branch: true
 

--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Load dependency updater defaults
         id: config
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/docker-ops.yml
+++ b/.github/workflows/docker-ops.yml
@@ -2,21 +2,6 @@
 name: Build/Release
 
 "on":
-  pull_request:
-    branches:
-      - latest
-    paths:
-      - ".github/workflows/docker-ops.yml"
-      - ".dockerignore"
-      - "Dockerfile"
-      - "bin/**"
-      - "lib/**"
-      - "src/**"
-      - "etc/**"
-      - "test/**"
-      - "Makefile"
-      - "Makefile.variables"
-      - "ci/**"
   push:
     branches:
       - "**"
@@ -37,7 +22,6 @@ name: Build/Release
 jobs:
   docker-ops:
     name: Docker Ops
-    if: github.event_name != 'pull_request'
     permissions:
       contents: write
       security-events: write
@@ -53,40 +37,9 @@ jobs:
     secrets:
       docker_token: ${{ secrets.DOCKER_TOKEN }}
 
-  docker-ops-pr:
-    name: Docker Ops PR Build
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Build worker image
-        run: make build IMAGE_NAME=worker-pr-validation TAG="${GITHUB_SHA}"
-
-      - name: Capture runtime output
-        run: |
-          mkdir -p runtime-output
-          docker run --rm \
-            -e WORKER_RUNTIME_OUTPUT=true \
-            "worker-pr-validation:${GITHUB_SHA}" \
-            true \
-            > runtime-output/runtime.json
-          jq -e '.env | type == "object"' runtime-output/runtime.json
-          jq -c . runtime-output/runtime.json
-
-      - name: Upload runtime output artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: worker-pr-runtime-output
-          path: runtime-output/runtime.json
-
   runtime-output:
     name: Runtime Output
     needs: docker-ops
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-ops.yml
+++ b/.github/workflows/docker-ops.yml
@@ -2,6 +2,21 @@
 name: Build/Release
 
 "on":
+  pull_request:
+    branches:
+      - latest
+    paths:
+      - ".github/workflows/docker-ops.yml"
+      - ".dockerignore"
+      - "Dockerfile"
+      - "bin/**"
+      - "lib/**"
+      - "src/**"
+      - "etc/**"
+      - "test/**"
+      - "Makefile"
+      - "Makefile.variables"
+      - "ci/**"
   push:
     branches:
       - "**"

--- a/.github/workflows/docker-ops.yml
+++ b/.github/workflows/docker-ops.yml
@@ -92,7 +92,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Build worker image
         run: make build IMAGE_NAME=worker-runtime-output TAG="${GITHUB_SHA}"

--- a/.github/workflows/docker-ops.yml
+++ b/.github/workflows/docker-ops.yml
@@ -37,6 +37,7 @@ name: Build/Release
 jobs:
   docker-ops:
     name: Docker Ops
+    if: github.event_name != 'pull_request'
     permissions:
       contents: write
       security-events: write
@@ -52,9 +53,40 @@ jobs:
     secrets:
       docker_token: ${{ secrets.DOCKER_TOKEN }}
 
+  docker-ops-pr:
+    name: Docker Ops PR Build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build worker image
+        run: make build IMAGE_NAME=worker-pr-validation TAG="${GITHUB_SHA}"
+
+      - name: Capture runtime output
+        run: |
+          mkdir -p runtime-output
+          docker run --rm \
+            -e WORKER_RUNTIME_OUTPUT=true \
+            "worker-pr-validation:${GITHUB_SHA}" \
+            true \
+            > runtime-output/runtime.json
+          jq -e '.env | type == "object"' runtime-output/runtime.json
+          jq -c . runtime-output/runtime.json
+
+      - name: Upload runtime output artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: worker-pr-runtime-output
+          path: runtime-output/runtime.json
+
   runtime-output:
     name: Runtime Output
     needs: docker-ops
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- request the udx/worker team on automated Docker dependency PRs
- apply explicit docker and dependencies labels when the updater creates a PR
- keep Build/Release validation on Docker/build/runtime branch pushes, matching the existing docker-ops trigger model
- include PR #141: bump actions/checkout from v6 to v7 across workflow checkouts
- add issues: write to the updater job so create-pull-request can apply labels through the Issues API

## Context
- PR #140 already has the right labels and now has the Worker team requested, but the updater workflow did not encode that behavior explicitly.
- Build/Release already runs on push for all branches with Docker/build/runtime path filters. That is the intended validation path for updater branches before merge.
- The reusable Docker release workflow distinguishes release vs feature branches internally through release_branch, so the caller should not add pull_request execution with release-capable permissions and Docker secrets.
- Related internal context: icamiami/icamiami.org#1931 tracks Copilot-assisted package security checks for APT pins, Cloud SDK, and standalone binaries.

## Validation
- Parsed updated workflow YAML with Ruby Psych.
- Ran git diff --check for the edited workflow files.
