### PR TITLE
Fix Docker dependency PR automation

### DIFF
--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -20,7 +20,11 @@ env:
   REPORT_PATH: docker-dependency-report.json
   UPDATE_BRANCH: docker-dependency-updates
   PR_TITLE: "chore(deps): docker dependency upgrade"
-  PR_AUTO_MERGE: "true"
+  PR_TEAM_REVIEWER: worker
+  PR_LABELS: |-
+    docker
+    dependencies
+  PR_AUTO_MERGE: "false"
   PR_MERGE_METHOD: squash
   COMMIT_MESSAGE: "chore(deps): update Docker dependency pins"
   COPILOT_PROMPT_PARTS: >-
@@ -55,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Load dependency updater defaults
         id: config
@@ -141,11 +145,12 @@ jobs:
 
     permissions:
       contents: write
+      issues: write
       pull-requests: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
 
@@ -382,6 +387,8 @@ jobs:
           body-path: docker-dependency-pr-body.md
           branch: ${{ needs.config.outputs.update_branch }}
           add-paths: ${{ needs.config.outputs.dockerfile }}
+          labels: ${{ env.PR_LABELS }}
+          team-reviewers: ${{ env.PR_TEAM_REVIEWER }}
           draft: false
           delete-branch: true
 

--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -379,7 +379,7 @@ jobs:
       - name: Create pull request
         id: create-pr
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@v8
         timeout-minutes: 5
         with:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -382,6 +382,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         timeout-minutes: 5
         with:
+          token: ${{ secrets.GH_TOKEN }}
           commit-message: ${{ needs.config.outputs.commit_message }}
           title: ${{ needs.config.outputs.pr_title }}
           body-path: docker-dependency-pr-body.md
@@ -416,7 +417,7 @@ jobs:
           esac
 
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           MERGE_METHOD: ${{ needs.config.outputs.pr_merge_method }}
           PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
 

--- a/.github/workflows/docker-ops.yml
+++ b/.github/workflows/docker-ops.yml
@@ -20,8 +20,24 @@ name: Build/Release
   workflow_dispatch:
 
 jobs:
+  control-gate:
+    name: Control Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject manual latest release
+        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'latest'
+        run: |
+          echo "::error::Manual latest releases are disabled. Merge to latest so the push trigger runs the release path."
+          exit 1
+
+      - name: Accept workflow trigger
+        run: |
+          echo "Build/Release accepted for ${GITHUB_EVENT_NAME} on ${GITHUB_REF_NAME}."
+
   docker-ops:
     name: Docker Ops
+    needs: control-gate
+    if: needs.control-gate.result == 'success'
     permissions:
       contents: write
       security-events: write
@@ -45,7 +61,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Build worker image
         run: make build IMAGE_NAME=worker-runtime-output TAG="${GITHUB_SHA}"

--- a/.github/workflows/docker-ops.yml
+++ b/.github/workflows/docker-ops.yml
@@ -20,24 +20,8 @@ name: Build/Release
   workflow_dispatch:
 
 jobs:
-  control-gate:
-    name: Control Gate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Reject manual latest release
-        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'latest'
-        run: |
-          echo "::error::Manual latest releases are disabled. Merge to latest so the push trigger runs the release path."
-          exit 1
-
-      - name: Accept workflow trigger
-        run: |
-          echo "Build/Release accepted for ${GITHUB_EVENT_NAME} on ${GITHUB_REF_NAME}."
-
   docker-ops:
     name: Docker Ops
-    needs: control-gate
-    if: needs.control-gate.result == 'success'
     permissions:
       contents: write
       security-events: write


### PR DESCRIPTION
## Summary
- keep Docker dependency releases push-driven by leaving updater auto-merge disabled
- use the existing GH_TOKEN service-account secret for generated Docker dependency PR branch writes and optional merge commands, so push-triggered Build/Release workflows are not suppressed by github.token
- make generated Docker dependency PRs request the udx/worker team and apply docker/dependencies labels
- include the checkout v7 update from PR #141
- use peter-evans/create-pull-request@v8, matching the org preference for major Action tags instead of raw SHA pins
- remove the temporary caller-side control gate from worker; docker-ops gate hardening belongs in udx/reusable-workflows

## Validation
- ruby YAML parse for docker-ops and docker-dependency-updater workflows
- git diff --check for both workflow files

## Notes
This fixes the PR #140 failure mode without manually releasing. The reusable docker-ops gate fix is intentionally separate and should land in udx/reusable-workflows.