### PR TITLE
fix(ci): set dependency PR service identity

### DIFF
--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -383,6 +383,8 @@ jobs:
         timeout-minutes: 5
         with:
           token: ${{ secrets.DEPENDABOT_REVIEWER_TOKEN || secrets.GH_TOKEN }}
+          author: udx-github <73100442+udx-github@users.noreply.github.com>
+          committer: udx-github <73100442+udx-github@users.noreply.github.com>
           commit-message: ${{ needs.config.outputs.commit_message }}
           title: ${{ needs.config.outputs.pr_title }}
           body-path: docker-dependency-pr-body.md


### PR DESCRIPTION
## Summary
- set Docker dependency PR commit author to udx-github
- set Docker dependency PR committer to udx-github

## Evidence
- udx-github user id: 73100442
- failed dependency run selected DEPENDABOT_REVIEWER_TOKEN but could not push: permission denied to udx-github

## Validation
- git diff --check
- ruby YAML parse for docker-dependency-updater.yml

## Follow-up outside this PR
- update the DEPENDABOT_REVIEWER_TOKEN PAT so it has repository access to udx/worker with Contents/Pull requests/Issues write