### PR TITLE
chore(deps): docker dependency upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ FROM ubuntu:25.10
 # Set the maintainer of the image
 LABEL maintainer="UDX CAG Team"
 
-ARG AZURE_CLI_VERSION=2.87.0
+ARG AZURE_CLI_VERSION=2.88.0
 ARG PIP_VERSION=26.1.2
 ARG YQ_VERSION=4.53.3
-ARG GCLOUD_VERSION=575.0.0
+ARG GCLOUD_VERSION=575.0.1
 
 # Set base environment variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -42,8 +42,8 @@ USER root
 # hadolint ignore=DL3015
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    tzdata=2026a-0ubuntu0.25.10.1  \
-    curl=8.14.1-2ubuntu1.4  \
+    tzdata=2026b-0ubuntu0.25.10.1  \
+    curl=8.14.1-2ubuntu1.5  \
     bash=5.2.37-2ubuntu5  \
     apt-utils=3.1.6ubuntu2 \
     gettext=0.23.1-2build2 \


### PR DESCRIPTION
## Summary

Updates Dockerfile dependency pins using a no-pin apt probe and Copilot CLI.

## Evidence

- Probe report artifact: `docker-dependency-report.json`
- Copilot session artifact: `copilot-docker-dependency-session.md`
- Build validation: handled by the repository Docker/CI workflows

## Diff

```diff
diff --git a/Dockerfile b/Dockerfile
index f919a01..5ace797 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ FROM ubuntu:25.10
 # Set the maintainer of the image
 LABEL maintainer="UDX CAG Team"
 
-ARG AZURE_CLI_VERSION=2.87.0
+ARG AZURE_CLI_VERSION=2.88.0
 ARG PIP_VERSION=26.1.2
 ARG YQ_VERSION=4.53.3
-ARG GCLOUD_VERSION=575.0.0
+ARG GCLOUD_VERSION=575.0.1
 
 # Set base environment variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -42,8 +42,8 @@ USER root
 # hadolint ignore=DL3015
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    tzdata=2026a-0ubuntu0.25.10.1  \
-    curl=8.14.1-2ubuntu1.4  \
+    tzdata=2026b-0ubuntu0.25.10.1  \
+    curl=8.14.1-2ubuntu1.5  \
     bash=5.2.37-2ubuntu5  \
     apt-utils=3.1.6ubuntu2 \
     gettext=0.23.1-2build2 \
```
