### PR TITLE
chore(deps): docker dependency upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ FROM ubuntu:25.10
 # Set the maintainer of the image
 LABEL maintainer="UDX CAG Team"
 
-ARG AZURE_CLI_VERSION=2.88.0
-ARG PIP_VERSION=26.2
+ARG AZURE_CLI_VERSION=2.89.0
+ARG PIP_VERSION=26.2.1
 ARG YQ_VERSION=4.53.3
-ARG GCLOUD_VERSION=578.0.0
+ARG GCLOUD_VERSION=579.0.0
 
 # Set base environment variables
 ENV DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
## Summary

Updates Dockerfile dependency pins using a no-pin apt probe and Copilot CLI.

## Evidence

- Probe report artifact: `docker-dependency-report.json`
- Copilot session artifact: `copilot-docker-dependency-session.md`
- Build validation: handled by the repository Docker/CI workflows

## Diff

```diff
diff --git a/Dockerfile b/Dockerfile
index 628c0da..3c5aa9f 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ FROM ubuntu:25.10
 # Set the maintainer of the image
 LABEL maintainer="UDX CAG Team"
 
-ARG AZURE_CLI_VERSION=2.88.0
-ARG PIP_VERSION=26.2
+ARG AZURE_CLI_VERSION=2.89.0
+ARG PIP_VERSION=26.2.1
 ARG YQ_VERSION=4.53.3
-ARG GCLOUD_VERSION=578.0.0
+ARG GCLOUD_VERSION=579.0.0
 
 # Set base environment variables
 ENV DEBIAN_FRONTEND=noninteractive \
```
